### PR TITLE
Create neon-themed Vyral React Native drawer app

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,120 @@
+import 'react-native-gesture-handler';
+import React from 'react';
+import { StatusBar, Platform, StyleSheet } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
+import { createDrawerNavigator } from '@react-navigation/drawer';
+import Icon from 'react-native-vector-icons/Ionicons';
+import HomeScreen from './screens/HomeScreen';
+import ModuleScreen from './screens/ModuleScreen';
+import NeonDrawerContent from './components/NeonDrawerContent';
+
+const Drawer = createDrawerNavigator();
+
+const moduleConfigs = [
+  {
+    name: 'Core',
+    description: 'Mission control for synchronized intelligence.',
+    icon: 'flash',
+  },
+  {
+    name: 'Zone',
+    description: 'Command the battlefield with spatial awareness.',
+    icon: 'planet',
+  },
+  {
+    name: 'Tree',
+    description: 'Visualize growth across the neon collective.',
+    icon: 'git-branch',
+  },
+  {
+    name: 'Board',
+    description: 'Panels of insight with adaptive metrics.',
+    icon: 'grid',
+  },
+  {
+    name: 'Stryke',
+    description: 'Accelerate momentum and strike the market.',
+    icon: 'trending-up',
+  },
+];
+
+const navigationTheme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    background: 'transparent',
+    card: '#070A15',
+    text: '#E8F6FF',
+    border: 'rgba(64, 89, 129, 0.4)',
+    primary: '#5FFFE3',
+  },
+};
+
+const createModuleScreen = (module) => () => (
+  <ModuleScreen
+    title={module.name}
+    description={module.description}
+    icon={<Icon name={module.icon} size={34} color="#66F7FF" />}
+    onAction={() => {}}
+  />
+);
+
+const App = () => (
+  <LinearGradient colors={['#03050B', '#020309']} style={{ flex: 1 }}>
+    <NavigationContainer theme={navigationTheme}>
+      <StatusBar translucent backgroundColor="transparent" barStyle="light-content" />
+      <Drawer.Navigator
+        initialRouteName="Home"
+        drawerContent={(props) => <NeonDrawerContent {...props} />}
+        screenOptions={{
+          headerTintColor: '#D7F8FF',
+          headerTitleStyle: {
+            letterSpacing: 2,
+            fontWeight: '700',
+          },
+          headerStyle: {
+            backgroundColor: '#050811',
+            borderBottomWidth: Platform.OS === 'ios' ? StyleSheet.hairlineWidth : 0,
+            borderBottomColor: 'rgba(90, 134, 255, 0.3)',
+            shadowColor: 'transparent',
+            elevation: 0,
+          },
+          drawerType: 'slide',
+          overlayColor: 'rgba(31, 242, 210, 0.08)',
+          drawerActiveTintColor: '#57FFE7',
+          drawerInactiveTintColor: 'rgba(190, 215, 255, 0.6)',
+          drawerStyle: {
+            backgroundColor: 'transparent',
+            width: 280,
+          },
+          sceneContainerStyle: {
+            backgroundColor: 'transparent',
+          },
+        }}
+      >
+        <Drawer.Screen
+          name="Home"
+          component={HomeScreen}
+          options={{
+            title: 'Vyral Home',
+            drawerIcon: ({ color, size }) => <Icon name="home" color={color} size={size} />,
+          }}
+        />
+        {moduleConfigs.map((module) => (
+          <Drawer.Screen
+            key={module.name}
+            name={module.name}
+            component={createModuleScreen(module)}
+            options={{
+              title: module.name,
+              drawerIcon: ({ color, size }) => <Icon name={module.icon} color={color} size={size} />,
+            }}
+          />
+        ))}
+      </Drawer.Navigator>
+    </NavigationContainer>
+  </LinearGradient>
+);
+
+export default App;

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "Vyral",
+  "displayName": "Vyral"
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['module:@react-native/babel-preset'],
+  plugins: ['react-native-reanimated/plugin'],
+};

--- a/components/ModuleCard.js
+++ b/components/ModuleCard.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+
+const ModuleCard = ({ title, description, children, icon }) => (
+  <LinearGradient colors={['rgba(26, 30, 44, 0.95)', 'rgba(16, 20, 34, 0.85)']} style={styles.card}>
+    <View style={styles.headerRow}>
+      <View style={styles.iconContainer}>{icon}</View>
+      <View style={styles.titleWrap}>
+        <Text style={styles.title}>{title}</Text>
+        {description ? <Text style={styles.subtitle}>{description}</Text> : null}
+      </View>
+    </View>
+    <View style={styles.content}>{children}</View>
+  </LinearGradient>
+);
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 24,
+    padding: 24,
+    marginVertical: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(110, 255, 233, 0.2)',
+    shadowColor: '#5B8AFF',
+    shadowOpacity: 0.3,
+    shadowRadius: 25,
+    shadowOffset: { width: 0, height: 14 },
+    elevation: 14,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  iconContainer: {
+    width: 64,
+    height: 64,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 16,
+    backgroundColor: 'rgba(30, 40, 60, 0.8)',
+    borderWidth: 1,
+    borderColor: 'rgba(111, 255, 224, 0.3)',
+  },
+  titleWrap: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#E8F6FF',
+    letterSpacing: 1,
+  },
+  subtitle: {
+    marginTop: 4,
+    fontSize: 14,
+    color: 'rgba(157, 187, 255, 0.7)',
+    letterSpacing: 0.5,
+  },
+  content: {
+    marginTop: 8,
+  },
+});
+
+export default ModuleCard;

--- a/components/NeonButton.js
+++ b/components/NeonButton.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+
+const NeonButton = ({ label, onPress }) => (
+  <TouchableOpacity activeOpacity={0.85} onPress={onPress} style={styles.shadowWrap}>
+    <LinearGradient colors={['#3FFFD7', '#8A4DFF']} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.gradient}>
+      <Text style={styles.text}>{label}</Text>
+    </LinearGradient>
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  shadowWrap: {
+    borderRadius: 18,
+    shadowColor: '#3FFFD7',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.45,
+    shadowRadius: 20,
+    elevation: 12,
+  },
+  gradient: {
+    borderRadius: 18,
+    paddingVertical: 14,
+    paddingHorizontal: 32,
+    alignItems: 'center',
+  },
+  text: {
+    color: '#0C101A',
+    fontSize: 18,
+    fontWeight: '700',
+    letterSpacing: 1,
+  },
+});
+
+export default NeonButton;

--- a/components/NeonDrawerContent.js
+++ b/components/NeonDrawerContent.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { View, Text, StyleSheet, ImageBackground } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+import { DrawerContentScrollView, DrawerItemList } from '@react-navigation/drawer';
+
+const NeonDrawerContent = (props) => (
+  <LinearGradient colors={['#05070D', '#0A1120']} style={styles.container}>
+    <ImageBackground
+      source={{ uri: 'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=600&q=80' }}
+      resizeMode="cover"
+      style={styles.headerBackground}
+      imageStyle={styles.headerImage}
+    >
+      <LinearGradient colors={['rgba(5,8,16,0.8)', 'rgba(13,18,35,0.4)']} style={styles.headerOverlay}>
+        <View style={styles.brandBadge}>
+          <Text style={styles.brandLetter}>V</Text>
+        </View>
+        <View>
+          <Text style={styles.brandName}>Vyral Suite</Text>
+          <Text style={styles.brandSubtitle}>Cybernetic Ops</Text>
+        </View>
+      </LinearGradient>
+    </ImageBackground>
+    <DrawerContentScrollView {...props} contentContainerStyle={styles.scrollArea}>
+      <DrawerItemList {...props} />
+    </DrawerContentScrollView>
+    <View style={styles.footer}>
+      <Text style={styles.footerText}>© {new Date().getFullYear()} Vyral Labs</Text>
+    </View>
+  </LinearGradient>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  headerBackground: {
+    padding: 24,
+    paddingTop: 48,
+  },
+  headerImage: {
+    borderBottomRightRadius: 32,
+    borderBottomLeftRadius: 32,
+    opacity: 0.45,
+  },
+  headerOverlay: {
+    backgroundColor: 'rgba(5, 10, 18, 0.72)',
+    borderBottomRightRadius: 32,
+    borderBottomLeftRadius: 32,
+    padding: 24,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+  },
+  brandBadge: {
+    width: 60,
+    height: 60,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(65, 242, 222, 0.18)',
+    borderWidth: 1,
+    borderColor: 'rgba(146, 107, 255, 0.6)',
+  },
+  brandLetter: {
+    color: '#5DCCFF',
+    fontSize: 30,
+    fontWeight: '700',
+    letterSpacing: 6,
+  },
+  brandName: {
+    color: '#E9FBFF',
+    fontSize: 20,
+    fontWeight: '700',
+    letterSpacing: 1,
+  },
+  brandSubtitle: {
+    color: 'rgba(180, 212, 255, 0.65)',
+    marginTop: 6,
+    letterSpacing: 1,
+  },
+  scrollArea: {
+    paddingTop: 8,
+  },
+  footer: {
+    paddingVertical: 20,
+    alignItems: 'center',
+    borderTopWidth: 1,
+    borderColor: 'rgba(47, 79, 124, 0.4)',
+  },
+  footerText: {
+    color: 'rgba(155, 200, 255, 0.5)',
+    letterSpacing: 0.5,
+  },
+});
+
+export default NeonDrawerContent;

--- a/components/VyralLogo.js
+++ b/components/VyralLogo.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+
+const VyralLogo = () => (
+  <View style={styles.wrapper}>
+    <LinearGradient colors={['#1B2235', '#080A12']} style={styles.logoBackground}>
+      <LinearGradient
+        colors={['#46FFE3', '#7F5BFF']}
+        start={{ x: 0.1, y: 0 }}
+        end={{ x: 0.9, y: 1 }}
+        style={styles.icon}
+      >
+        <Text style={styles.symbol}>⚡</Text>
+      </LinearGradient>
+    </LinearGradient>
+    <Text style={styles.title}>Vyral</Text>
+    <Text style={styles.subtitle}>Neon Synergy Platform</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  wrapper: {
+    alignItems: 'center',
+  },
+  logoBackground: {
+    width: 160,
+    height: 160,
+    borderRadius: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#3CF9E3',
+    shadowOpacity: 0.5,
+    shadowOffset: { width: 0, height: 24 },
+    shadowRadius: 40,
+    elevation: 20,
+  },
+  icon: {
+    width: 120,
+    height: 120,
+    borderRadius: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#8B5BFF',
+    shadowOpacity: 0.4,
+    shadowRadius: 30,
+    shadowOffset: { width: 0, height: 14 },
+  },
+  symbol: {
+    fontSize: 68,
+    color: '#0E1422',
+  },
+  title: {
+    marginTop: 24,
+    fontSize: 38,
+    color: '#E6F7FF',
+    fontWeight: '700',
+    letterSpacing: 4,
+    textTransform: 'uppercase',
+  },
+  subtitle: {
+    marginTop: 8,
+    color: 'rgba(164, 200, 255, 0.7)',
+    fontSize: 16,
+    letterSpacing: 1,
+  },
+});
+
+export default VyralLogo;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+import 'react-native-gesture-handler';
+import { AppRegistry } from 'react-native';
+import App from './App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "vyral",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "@react-navigation/drawer": "^6.6.3",
+    "@react-navigation/native": "^6.1.9",
+    "@react-navigation/native-stack": "^6.9.17",
+    "react": "18.2.0",
+    "react-native": "0.73.6",
+    "react-native-gesture-handler": "^2.14.0",
+    "react-native-linear-gradient": "^2.8.2",
+    "react-native-reanimated": "^3.6.1",
+    "react-native-safe-area-context": "^4.9.0",
+    "react-native-screens": "^3.29.0",
+    "react-native-vector-icons": "^10.0.3"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.0",
+    "@babel/runtime": "^7.24.0",
+    "@react-native/babel-preset": "^0.73.21",
+    "metro-react-native-babel-preset": "^0.76.7"
+  }
+}

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+import VyralLogo from '../components/VyralLogo';
+import ModuleCard from '../components/ModuleCard';
+import NeonButton from '../components/NeonButton';
+import Icon from 'react-native-vector-icons/Ionicons';
+
+const HomeScreen = ({ navigation }) => {
+  const modules = [
+    { key: 'Core', icon: 'flash', description: 'Mission control and operational intelligence.' },
+    { key: 'Zone', icon: 'aperture', description: 'Spatial analytics and live command zones.' },
+    { key: 'Tree', icon: 'git-network', description: 'Organizational mapping and lineage tracking.' },
+    { key: 'Board', icon: 'grid', description: 'Strategic dashboards and visualization.' },
+    { key: 'Stryke', icon: 'rocket', description: 'Revenue acceleration and sales orchestration.' },
+  ];
+
+  return (
+    <LinearGradient colors={['#050712', '#060B1A', '#020408']} style={styles.background}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <VyralLogo />
+        <Text style={styles.tagline}>Plug into the neon network. Power every mission.</Text>
+        <View style={styles.modulesWrap}>
+          {modules.map((module) => (
+            <ModuleCard
+              key={module.key}
+              title={module.key}
+              description={module.description}
+              icon={<Icon name={module.icon} size={32} color="#6DF7FF" />}
+            >
+              <NeonButton label={`Launch ${module.key}`} onPress={() => navigation.navigate(module.key)} />
+            </ModuleCard>
+          ))}
+        </View>
+      </ScrollView>
+    </LinearGradient>
+  );
+};
+
+const styles = StyleSheet.create({
+  background: {
+    flex: 1,
+  },
+  content: {
+    padding: 24,
+    paddingTop: 64,
+    paddingBottom: 120,
+  },
+  tagline: {
+    textAlign: 'center',
+    marginTop: 24,
+    fontSize: 16,
+    color: 'rgba(166, 210, 255, 0.75)',
+    letterSpacing: 1,
+  },
+  modulesWrap: {
+    marginTop: 16,
+  },
+});
+
+export default HomeScreen;

--- a/screens/ModuleScreen.js
+++ b/screens/ModuleScreen.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+import ModuleCard from '../components/ModuleCard';
+import NeonButton from '../components/NeonButton';
+
+const ModuleScreen = ({ title, description, icon, onAction }) => (
+  <LinearGradient colors={['#04060F', '#070B1B']} style={styles.background}>
+    <View style={styles.overlay}>
+      <ModuleCard title={title} description={description} icon={icon}>
+        <Text style={styles.bodyText}>
+          {`The ${title} module is charging up its neon systems. Tap below to simulate an action while the team crafts the full feature set.`}
+        </Text>
+        <View style={styles.buttonWrap}>
+          <NeonButton label={`Engage ${title}`} onPress={onAction} />
+        </View>
+      </ModuleCard>
+    </View>
+  </LinearGradient>
+);
+
+const styles = StyleSheet.create({
+  background: {
+    flex: 1,
+  },
+  overlay: {
+    flex: 1,
+    padding: 24,
+    paddingTop: 64,
+  },
+  bodyText: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: 'rgba(183, 214, 255, 0.8)',
+  },
+  buttonWrap: {
+    marginTop: 24,
+    alignItems: 'flex-start',
+  },
+});
+
+export default ModuleScreen;


### PR DESCRIPTION
## Summary
- set up React Native project scaffolding with navigation entry points and configuration
- implement neon-themed Vyral home screen, module screens, and reusable components for branding and buttons
- customize drawer navigation with bespoke styling and icons for Core, Zone, Tree, Board, and Stryke modules

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8843d95488321a487e1bc2bcb5a97