### PR TITLE
Replace linear gradient dependency with Expo package

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,7 +1,7 @@
 import 'react-native-gesture-handler';
 import React from 'react';
 import { StatusBar, Platform, StyleSheet } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
+import { LinearGradient } from 'expo-linear-gradient';
 import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
 import { createDrawerNavigator } from '@react-navigation/drawer';
 import Icon from 'react-native-vector-icons/Ionicons';

--- a/components/NeonDrawerContent.js
+++ b/components/NeonDrawerContent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, ImageBackground } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
+import { LinearGradient } from 'expo-linear-gradient';
 import { DrawerContentScrollView, DrawerItemList } from '@react-navigation/drawer';
 
 const NeonDrawerContent = (props) => (

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react": "18.2.0",
     "react-native": "0.73.6",
     "react-native-gesture-handler": "^2.14.0",
-    "react-native-linear-gradient": "^2.8.2",
+    "expo-linear-gradient": "~13.0.2",
     "react-native-reanimated": "^3.6.1",
     "react-native-safe-area-context": "^4.9.0",
     "react-native-screens": "^3.29.0",

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
+import { LinearGradient } from 'expo-linear-gradient';
 import VyralLogo from '../components/VyralLogo';
 import ModuleCard from '../components/ModuleCard';
 import NeonButton from '../components/NeonButton';

--- a/screens/ModuleScreen.js
+++ b/screens/ModuleScreen.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
+import { LinearGradient } from 'expo-linear-gradient';
 import ModuleCard from '../components/ModuleCard';
 import NeonButton from '../components/NeonButton';
 


### PR DESCRIPTION
## Summary
- replace the react-native-linear-gradient dependency with expo-linear-gradient
- update gradient imports in the app to use the Expo LinearGradient component

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d88ac5947c832182021d2d21ab5b6e