### PR TITLE
Use expo linear gradient in UI components

### DIFF
--- a/components/ModuleCard.js
+++ b/components/ModuleCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
+import { LinearGradient } from 'expo-linear-gradient';
 
 const ModuleCard = ({ title, description, children, icon }) => (
   <LinearGradient colors={['rgba(26, 30, 44, 0.95)', 'rgba(16, 20, 34, 0.85)']} style={styles.card}>

--- a/components/NeonButton.js
+++ b/components/NeonButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TouchableOpacity, Text, StyleSheet } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
+import { LinearGradient } from 'expo-linear-gradient';
 
 const NeonButton = ({ label, onPress }) => (
   <TouchableOpacity activeOpacity={0.85} onPress={onPress} style={styles.shadowWrap}>

--- a/components/VyralLogo.js
+++ b/components/VyralLogo.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
+import { LinearGradient } from 'expo-linear-gradient';
 
 const VyralLogo = () => (
   <View style={styles.wrapper}>


### PR DESCRIPTION
## Summary
- replace `react-native-linear-gradient` with the Expo `LinearGradient` component in ModuleCard, NeonButton, and VyralLogo

## Testing
- not run (Expo CLI interactive commands are not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d88d046c088321bf5d9620dee64f3d