### PR TITLE
Expand drawer modules

### DIFF
--- a/lib/localModuleData.js
+++ b/lib/localModuleData.js
@@ -64,6 +64,45 @@ const moduleDefinitions = [
     actionLabel: 'Launch Stryke',
     actionCopy: 'Ignite a sales sequence and rally the revenue squad.',
   },
+  {
+    id: 'skrybe',
+    key: 'Skrybe',
+    moduleKey: 'Skrybe',
+    title: 'Skrybe Forge',
+    description: 'Narrative studio for collaborative lore and story drops.',
+    longDescription:
+      'Spin up serialized story worlds, draft collaborative chapters, and keep the lore canon synced across every squad.',
+    icon: 'create-outline',
+    routeName: 'Skrybe',
+    actionLabel: 'Launch Skrybe',
+    actionCopy: 'Open the narrative forge and publish a new neon chronicle.',
+  },
+  {
+    id: 'lyfe',
+    key: 'Lyfe',
+    moduleKey: 'Lyfe',
+    title: 'Lyfe Pulse',
+    description: 'Wellness quests with adaptive rituals and streaks.',
+    longDescription:
+      'Track vibes, unlock resilience quests, and align check-ins that keep every creator balanced and energized.',
+    icon: 'heart-outline',
+    routeName: 'Lyfe',
+    actionLabel: 'Launch Lyfe',
+    actionCopy: 'Initiate a wellness pulse and log a new resilience ritual.',
+  },
+  {
+    id: 'vshop',
+    key: 'Vshop',
+    moduleKey: 'Vshop',
+    title: 'Vshop Arena',
+    description: 'Drop hub for digital merch, experiences, and unlocks.',
+    longDescription:
+      'Curate neon drops, bundle virtual meetups, and manage fan commerce funnels with cinematic flair.',
+    icon: 'bag-handle-outline',
+    routeName: 'Vshop',
+    actionLabel: 'Launch Vshop',
+    actionCopy: 'Preview the next merch cascade and ready the hype signals.',
+  },
 ];
 
 export const getAllModules = () =>


### PR DESCRIPTION
## Summary
- load drawer module entries from the shared module metadata so fallback and Supabase data surface automatically
- add fallback definitions for Skrybe, Lyfe, and Vshop so their navigation routes include descriptions and icons

## Testing
- not run (Expo CLI start requires an interactive environment)

------
https://chatgpt.com/codex/tasks/task_e_68d8b9cfe57083219350c1015b2f4d61